### PR TITLE
move from branch beta to 21.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.dotnet6.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet6.yaml
@@ -1,5 +1,5 @@
 app-id: org.freedesktop.Sdk.Extension.dotnet6
-branch: 'beta'
+branch: '21.08'
 runtime: org.freedesktop.Sdk
 runtime-version: '21.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
Having this extension on branch `beta` makes it invisible to applications requesting runtime `org.freedesktop.Sdk//21.08`.