### PR TITLE
feature: add enable.sh for compatibility with VSCode's and Jebrains' flatpaks

### DIFF
--- a/org.freedesktop.Sdk.Extension.dotnet6.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet6.yaml
@@ -58,7 +58,7 @@ modules:
     buildsystem: simple
     build-commands:
       - 'mkdir -p /usr/lib/sdk/dotnet6/share/appdata'
-      - 'cp install.sh install-sdk.sh /usr/lib/sdk/dotnet6/bin'
+      - 'cp enable.sh install.sh install-sdk.sh /usr/lib/sdk/dotnet6/bin'
       - 'cp org.freedesktop.Sdk.Extension.dotnet6.appdata.xml ${FLATPAK_DEST}/share/appdata'
       - 'appstream-compose --basename=org.freedesktop.Sdk.Extension.dotnet6 --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.dotnet6'
     sources:
@@ -75,5 +75,13 @@ modules:
           - '/usr/lib/sdk/dotnet6/bin/install.sh'
           - 'cp -r /usr/lib/sdk/dotnet6/lib/sdk /app/lib/dotnet'
         dest-filename: install-sdk.sh
+      - type: script
+        commands:
+          - 'export PATH=$PATH:/usr/lib/sdk/dotnet6/bin'
+          - 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/sdk/dotnet6/lib'
+          - 'export DOTNET_CLI_TELEMETRY_OPTOUT=true'
+          - 'export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true'
+          - 'export DOTNET_ROOT=/usr/lib/sdk/dotnet6/lib'
+        dest-filename: enable.sh
       - type: file
         path: org.freedesktop.Sdk.Extension.dotnet6.appdata.xml


### PR DESCRIPTION
[VisualStudio Code](https://github.com/flathub/com.visualstudio.code) and [Jetbrains IDEs](https://github.com/Lctrs/jetbrains-flatpak-wrapper) rely on the presence of the `enable.sh` script in an SDK extension root to set the environment to use the SDK.