### PR TITLE
Use a custom f-e-d-c workflow to update multiple branches

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,30 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 * * * *" # run every hour
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ branch/21.08, branch/22.08 ] # list all branches to check
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork org.freedesktop.Sdk.Extension.dotnet6.yaml

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
   "only-arches": ["x86_64", "aarch64"],
-  "skip-icons-check": true
+  "skip-icons-check": true,
+  "disable-external-data-checker": true
 }


### PR DESCRIPTION
Currently, the flathub-hosted flatpak-external-data-checker only checks the default branch of each repo for updates (see https://github.com/flathub/flatpak-external-data-checker/issues/75). This has happened last month for dotnet 6.0.402 ([automatic PR for branch/21.08](https://github.com/flathub/org.freedesktop.Sdk.Extension.dotnet6/pull/29), [manual PR for branch/22.08](https://github.com/flathub/org.freedesktop.Sdk.Extension.dotnet6/pull/30)), and it has happened again a couple of days ago for dotnet 6.0.403 ([automatic PR for branch/21.08](https://github.com/flathub/org.freedesktop.Sdk.Extension.dotnet6/pull/31), no PR yet for branch/22.08).

The suggested workaround is to disable the checker in `flathub.json` and use a [custom workflow](https://github.com/flathub/flatpak-external-data-checker#custom-workflow) instead. Note that this only works if the workflow file is in the default branch, so when/if the default branch is changed, the workflow file should be copied to the new branch too.